### PR TITLE
Return channel as <channel>.<subchannel>

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -233,7 +233,7 @@ const commands = {
                 channel = parseInt(channel, 10);
                 subchannel = parseInt(subchannel.replace(/8*$/, ''), 10);
 
-                return { channel, subchannel };
+                return [ channel, subchannel ].join('.');
             }
         }
     },


### PR DESCRIPTION
Return in this format (rather than JS object) to match the format expected when parsing input channels.

Fixes https://github.com/forty2/bravia2mqtt/issues/2